### PR TITLE
public folder does not work as advertised

### DIFF
--- a/src/server/public/index.html
+++ b/src/server/public/index.html
@@ -59,7 +59,7 @@
       <hr>
 
       <p>
-        <i>To replace this page, create an index.html file in ./public, JSON Server will load it.</i>
+        <i>To replace this page with an empty page just create ./public folder. To have your own index.html place it in the ./public folder and JSON Server will load it.</i>
       </p>
     </div>
 


### PR DESCRIPTION
When having just the ./public folder the default behaviour is serving an empty page. So I changed the text accordingly.

I rather had the API pages still intact and it would be great that get access to it even after creating a ./public/index.
